### PR TITLE
SDK Configuration - IgnoreErrors and Fingerprinting

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,6 @@ func main() {
 		Debug:            true,
 		AttachStacktrace: true,
 		ServerName:       "ServerName",
-		SampleRate:       1.0, // TODO test
 		IgnoreErrors:     []string{"MyIOError", "MyDBError"},
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			fmt.Println(event.EventID)
@@ -277,5 +276,5 @@ type DatabaseConnectionError struct {
 }
 
 func (e DatabaseConnectionError) Error() string {
-	return "CustomComplexError: " + e.Message
+	return "DatabaseConnectionError: " + e.Message
 }


### PR DESCRIPTION
- [ ]  Bugfix
- [ ]  New feature
- [x]  Enhancement
- [x]  Refactoring
## Description
Add in the SDK Configuration features that were lacking. This includes IgnoreErrors, and fingerprinting.

## Testing
#### IgnoreErrors
tested by ignoring the error that the /handled endpoint produces, which is `"open filename.ext: no such file or directory"`.
Here was the config:
```
IgnoreErrors:     []string{"open filename.ext: no such file or directory"}
```
and here was the output that it was successfully ignored:
```
transaction: GET /handled
[Sentry] 2020/12/18 15:55:25 Event dropped due to being matched by `IgnoreErrors` option.| Value matched: open filename.ext: no such file or directory | Filter used: open filename.ext: no such file or directory
[Sentry] 2020/12/18 15:55:25 Event dropped by one of the Client EventProcessors: 82dcc01013e944828b7c50e60d75bad3
[Sentry] 2020/12/18 15:55:25 Sending transaction [ea16ae091e1d4e0a8c88d2d817fc3c92] to o87286.ingest.sentry.io project: 5426957
```

#### fingerprinting
/handled
https://sentry.io/organizations/testorg-az/discover/go-wcap:132aee95d1c9434dbbf1ab5943bd6d8b/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5426957&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1
![image](https://user-images.githubusercontent.com/8920574/102666015-98646100-414b-11eb-8ad1-0a8287611abf.png)


/handled
https://sentry.io/organizations/testorg-az/issues/2101816196/?project=5426957&query=is%3Aunresolved

/unhandled
https://sentry.io/organizations/testorg-az/issues/2101820163/?project=5426957&query=is%3Aunresolved

/success(transaction) still works
https://sentry.io/organizations/testorg-az/discover/go-wcap:6c6a62d7989149698e51a9a72ceb1995/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5426957&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1
